### PR TITLE
Add hover options to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 -   `markuplint.enable`: Control whether markuplint is enabled for HTML files or not
 -   `markuplint.debug`: Enable debug mode
 -   `markuplint.defaultConfig`: It's the configuration specified if configuration files do not exist
--   `markuplint.showAccessibility`: Enable the feature that **popup Accessibility Object**
--   `markuplint.showAccessibility.ariaVersion`: Set `1.1` or `1.2` WAI-ARIA version; Default is `1.2`.
+-   `markuplint.hover.accessibility.enable`: Enable the feature that **popup Accessibility Object**
+-   `markuplint.hover.accessibility.ariaVersion`: Set `1.1` or `1.2` WAI-ARIA version; Default is `1.2`.
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,20 @@
 							"markuplint:recommended"
 						]
 					}
+				},
+				"markuplint.hover.accessibility.enable": {
+					"type": "boolean",
+					"markdownDescription": "Enable the feature that **popup Accessibility Object**",
+					"default": true
+				},
+				"markuplint.hover.accessibility.ariaVersion": {
+					"type": "string",
+					"enum": [
+						"1.1",
+						"1.2"
+					],
+					"markdownDescription": "Set `1.1` or `1.2` WAI-ARIA version; Default is `1.2`.",
+					"default": "1.2"
 				}
 			}
 		},

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -139,13 +139,13 @@ export async function bootServer() {
 
 	connection.onHover(async (params) => {
 		const { langConfigs } = await initialized;
-		const showAccessibility = langConfigs['html']?.showAccessibility ?? true;
+		const accessibilityConfig = langConfigs['html']?.hover.accessibility ?? { enable: true, ariaVersion: '1.2' };
 
-		if (!showAccessibility) {
+		if (!accessibilityConfig.enable) {
 			return;
 		}
 
-		const ariaVersion = typeof showAccessibility === 'boolean' ? '1.2' : showAccessibility.ariaVersion;
+		const ariaVersion = accessibilityConfig.ariaVersion;
 
 		const node = v3.getNodeWithAccessibilityProps(params.textDocument, params.position, ariaVersion);
 
@@ -157,8 +157,8 @@ export async function bootServer() {
 
 		const props = node.exposed
 			? `${Object.entries(node.aria)
-					.map(([key, value]) => `- ${key}: ${value}`)
-					.join('\n')}`
+				.map(([key, value]) => `- ${key}: ${value}`)
+				.join('\n')}`
 			: '\n**No exposed to accessibility tree** (hidden element)';
 
 		return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,12 @@ export type Config = {
 	enable: boolean;
 	debug: boolean;
 	defaultConfig: MLConfig;
-	showAccessibility:
-		| boolean
-		| {
-				ariaVersion: ARIAVersion;
-		  };
+	hover: {
+		accessibility: {
+			enable: boolean;
+			ariaVersion: ARIAVersion;
+		};
+	}
 };
 
 export type LangConfigs = Record<string, Config>;


### PR DESCRIPTION
Fix markuplint/markuplint#794 

- Change option name to `markuplint.hover.accessibility.enable` and `markuplint.hover.accessibility.ariaVersion`
  - according to other extensions' naming
- Add options to package.json, in order to allow user to set values